### PR TITLE
Reconnect on initialization error, Fix #2

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const UNDEFINED_TABLE = '42P01'
-const INTERNAL_ERROR = 'XX000'
+const DATABASE_IS_STARTING_UP = '57P03'
+const CONNECTION_REFUSED = 'ECONNREFUSED'
 const events = require( 'events' )
 const util = require( 'util' )
 const pckg = require( '../package.json' )
@@ -345,13 +346,7 @@ module.exports = class Connector extends events.EventEmitter {
   _initialise() {
     this.query( this.statements.initDb( this.options.schema ), ( error, result ) => {
       if( error ) {
-        // retry for errors caused by concurrent initialisation
-        if( error.code === INTERNAL_ERROR ) {
-          this._initialise()
-          return
-        } else {
-          throw error
-        }
+        return this._initialise()
       }
       utils.checkVersion( result.rows[ 0 ].version )
       this.isReady = true
@@ -370,7 +365,7 @@ module.exports = class Connector extends events.EventEmitter {
    * @returns {void}
    */
   _checkError( error, message ) {
-    if( error ) {
+    if( error && error.code !== DATABASE_IS_STARTING_UP && error.code !== CONNECTION_REFUSED ) {
       console.log( error, message )
     }
   }

--- a/src/connector.js
+++ b/src/connector.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const UNDEFINED_TABLE = '42P01'
+const INTERNAL_ERROR = 'XX000'
 const DATABASE_IS_STARTING_UP = '57P03'
 const CONNECTION_REFUSED = 'ECONNREFUSED'
 const events = require( 'events' )
@@ -346,7 +347,15 @@ module.exports = class Connector extends events.EventEmitter {
   _initialise() {
     this.query( this.statements.initDb( this.options.schema ), ( error, result ) => {
       if( error ) {
-        return this._initialise()
+        // retry for errors caused by concurrent initialisation
+        // or when the DB can't be reached (e.g. it's still starting up in a Docker setup)
+        if( error.code === INTERNAL_ERROR ||
+            error.code === DATABASE_IS_STARTING_UP ||
+            error.code === CONNECTION_REFUSED ) {
+          return this._initialise()
+        } else {
+          throw error
+        }
       }
       utils.checkVersion( result.rows[ 0 ].version )
       this.isReady = true


### PR DESCRIPTION
As discussed in #2. It will reconnect on an error until the `dependencyInitialisationTimeout ` setting from Deepstream kicks in.

This PR needs #5 in order to work properly.