### PR TITLE
added jsonb option and turned notifications of by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.0] - 2017-05-30
+
+### Performance Improvements
+- Disabled notifications by default
+- Changed default column type for value to text
+- Introduced `useJsonb` option to enable storage as binary json
+
 ## [1.0.1] - 2017-02-12
 
 ### Miscellaneous

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ plugins:
       schema: ds #schema defaults to ds. Will be created if it doesn't exist
       max: 10 #concurrent connections
       idleTimeoutMillis: 30000 #timeout after which connection will be cut
-      writeInterval: 200 #amout of milliseconds during which writes will be buffered
+      writeInterval: 200 #amout of milliseconds during which writes will be 
+      useJsonb: false #store values as searchable binary JSON (slower)
+      buffered
       notifications:
-        CREATE_TABLE: true #Get notified when tables are created
-        DESTROY_TABLE: true #Get notified when tables are dropped
-        INSERT: true # Get notified when records are created
+        CREATE_TABLE: false #Get notified when tables are created
+        DESTROY_TABLE: false #Get notified when tables are dropped
+        INSERT: false # Get notified when records are created
         UPDATE: false # Get notified when records are updated
-        DELETE: true # Get notified when records are deleted
+        DELETE: false # Get notified when records are deleted
 ```
 
 This connector can also be used as a standalone component from node.js to connect to postgres' notification mechanism. To do this, install the connector via

--- a/src/connector.js
+++ b/src/connector.js
@@ -221,7 +221,12 @@ module.exports = class Connector extends events.EventEmitter {
         callback( null, null )
       }
       else {
-        callback( null, result.rows[ 0 ].val )
+        if( typeof result.rows[ 0 ].val !== 'string' ) {
+          callback( null,  result.rows[ 0 ].val )
+        } else {
+          callback( null, JSON.parse( result.rows[ 0 ].val ) )
+        }
+        
       }
     }, null, true )
   }
@@ -302,12 +307,13 @@ module.exports = class Connector extends events.EventEmitter {
     this._checkOption( 'idleTimeoutMillis', 'number', 30000 )
     this._checkOption( 'writeInterval', 'number', 200 )
     this._checkOption( 'schema', 'string', 'ds' )
+    this._checkOption( 'useJsonb', 'boolean', false )
     this._checkOption( 'notifications', 'object',  {
-      CREATE_TABLE: true,
-      DESTROY_TABLE: true,
-      INSERT: true,
+      CREATE_TABLE: false,
+      DESTROY_TABLE: false,
+      INSERT: false,
       UPDATE: false,
-      DELETE: true
+      DELETE: false
     })
   }
 

--- a/src/statements.js
+++ b/src/statements.js
@@ -54,7 +54,7 @@ module.exports = class Statements{
     CREATE TABLE "${params.schema}"."${params.table}"
     (
         id text NOT NULL,
-        val jsonb NOT NULL,
+        val ${this._options.useJsonb ? 'jsonb' : 'text'} NOT NULL,
         PRIMARY KEY (id)
     )
     WITH (

--- a/test/cache-connectorSpec.js
+++ b/test/cache-connectorSpec.js
@@ -12,7 +12,14 @@ const settings = {
   host: process.env.PGHOST,
   port: parseInt( process.env.PGPORT, 10 ),
   max: 10,
-  idleTimeoutMillis: 30000
+  idleTimeoutMillis: 30000,
+  notifications: {
+    CREATE_TABLE: true,
+    DESTROY_TABLE: true,
+    INSERT: true,
+    UPDATE: false,
+    DELETE: true
+  }
 }
 
 


### PR DESCRIPTION
This pull request improves postgres performance by 3.5 - 5x by disabling notifications by default and changing the column type for value storage to text (whilst introducing a `useJsonb` option to enable it again,)

![image](https://cloud.githubusercontent.com/assets/1503717/26583011/a6c013a0-4543-11e7-9a13-9f7b5528d323.png)
